### PR TITLE
Thaumcraft 6 support + Allow blocks to be missing in AE2

### DIFF
--- a/internal/appliedenergistics2/whitelist.jsonc
+++ b/internal/appliedenergistics2/whitelist.jsonc
@@ -1,6 +1,7 @@
 // DO NOT EDIT!
 [
     {
+        "allowMissing": true,
         "blockId": [
             "appliedenergistics2:cable_bus",
             "appliedenergistics2:charger",

--- a/internal/thaumcraft/whitelist.jsonc
+++ b/internal/thaumcraft/whitelist.jsonc
@@ -1,0 +1,103 @@
+// DO NOT EDIT!
+[
+        {
+        "blockId": [
+            "thaumcraft:crystal_aer",
+            "thaumcraft:crystal_ignis",
+            "thaumcraft:crystal_aqua",
+            "thaumcraft:crystal_terra",
+            "thaumcraft:crystal_ordo",
+            "thaumcraft:crystal_perditio",
+            "thaumcraft:crystal_vitium",
+            "thaumcraft:table_wood",
+            "thaumcraft:table_stone",
+            "thaumcraft:pedestal_arcane",
+            "thaumcraft:pedestal_ancient",
+            "thaumcraft:pedestal_eldritch",
+            "thaumcraft:pillar_arcane",
+            "thaumcraft:pillar_ancient",
+            "thaumcraft:pillar_eldritch",
+            "thaumcraft:banner_white",
+            "thaumcraft:banner_orange",
+            "thaumcraft:banner_magenta",
+            "thaumcraft:banner_lightblue",
+            "thaumcraft:banner_yellow",
+            "thaumcraft:banner_lime",
+            "thaumcraft:banner_pink",
+            "thaumcraft:banner_gray",
+            "thaumcraft:banner_silver",
+            "thaumcraft:banner_cyan",
+            "thaumcraft:banner_purple",
+            "thaumcraft:banner_blue",
+            "thaumcraft:banner_brown",
+            "thaumcraft:banner_green",
+            "thaumcraft:banner_red",
+            "thaumcraft:banner_black",
+            "thaumcraft:banner_crimson_cult",
+            "thaumcraft:inlay",
+            "thaumcraft:arcane_workbench_charger",
+            "thaumcraft:arcane_ear",
+            "thaumcraft:arcane_ear_toggle",
+            "thaumcraft:lamp_arcane",
+            "thaumcraft:lamp_fertility",
+            "thaumcraft:lamp_growth",
+            "thaumcraft:centrifuge",
+            "thaumcraft:bellows",
+            "thaumcraft:smelter_aux",
+            "thaumcraft:smelter_vent",
+            "thaumcraft:alembic",
+            "thaumcraft:hungry_chest",
+            "thaumcraft:tube",
+            "thaumcraft:tube_valve",
+            "thaumcraft:tube_restrict",
+            "thaumcraft:tube_oneway",
+            "thaumcraft:tube_filter",
+            "thaumcraft:tube_buffer",
+            "thaumcraft:jar_normal",
+            "thaumcraft:jar_void",
+            "thaumcraft:jar_brain",
+            "thaumcraft:infusion_matrix",
+            "thaumcraft:everfull_urn",
+            "thaumcraft:brain_box",
+            "thaumcraft:thaumatorium",
+            "thaumcraft:mirror",
+            "thaumcraft:mirror_essentia",
+            "thaumcraft:essentia_input",
+            "thaumcraft:essentia_output",
+            "thaumcraft:redstone_relay",
+            "thaumcraft:stabilizer",
+            "thaumcraft:vis_generator",
+            "thaumcraft:condenser",
+            "thaumcraft:condenser_lattice",
+            "thaumcraft:condenser_lattice_dirty",
+            "thaumcraft:void_siphon",
+            "thaumcraft:golem_builder",
+            "thaumcraft:taint_fibre",
+            "thaumcraft:taint_feature"
+        ]
+    },
+    {
+        "blockId": [
+            "thaumcraft:loot_crate_common",
+            "thaumcraft:loot_crate_uncommon",
+            "thaumcraft:loot_crate_rare",
+            "thaumcraft:loot_urn_common",
+            "thaumcraft:loot_urn_uncommon",
+            "thaumcraft:loot_urn_rare"
+        ],
+        "canFluidFlow": true
+    },
+    {
+        "blockId": [
+            "thaumcraft:pattern_crafter",
+            "thaumcraft:research_table"
+        ],
+        "canFluidFlow": ["north", "south", "east", "west", "down"]
+    },
+    {
+        "blockId": [
+            "thaumcraft:recharge_pedestal"
+        ],
+        "canFluidFlow": ["north", "south", "east", "west", "up"]
+    }
+]

--- a/internal/versions.jsonc
+++ b/internal/versions.jsonc
@@ -12,7 +12,7 @@
     "alternatingflux": 1,
     "aoa3": 1,
     "apotheosis": 1,
-    "appliedenergistics2": 1,
+    "appliedenergistics2": 2,
     "architecturecraft": 1,
     "armorplus": 1,
     "artisanworktables": 1,

--- a/internal/versions.jsonc
+++ b/internal/versions.jsonc
@@ -117,6 +117,7 @@
     "survivalist": 1,
     "tconstruct": 1,
     "telepads": 1,
+    "thaumcraft": 1,
     "thebetweenlands": 1,
     "thermaldynamics": 1,
     "thermalexpansion": 1,


### PR DESCRIPTION
Support for [TC6](https://www.curseforge.com/minecraft/mc-mods/thaumcraft) and allow blocks to be missing for [AE2](https://www.curseforge.com/minecraft/mc-mods/applied-energistics-2) since they can be disabled in its configs.